### PR TITLE
Harmony patches to prevent baby feeding attempts

### DIFF
--- a/Source/MealPrinter/Harmony_JobGiver_Autofeed.cs
+++ b/Source/MealPrinter/Harmony_JobGiver_Autofeed.cs
@@ -1,0 +1,90 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System.Collections.Generic;
+using Verse;
+using Verse.AI;
+
+namespace MealPrinter
+{
+    [HarmonyPatch(typeof(JobGiver_Autofeed), "TryGiveJob")]
+    public static class Harmony_JobGiver_Autofeed_TryGiveJob
+    {
+        public static bool Prefix(JobGiver_Autofeed __instance, ref Job __result, Pawn pawn)
+        {
+            if (!pawn.CanReserve(pawn))
+            {
+                __result = null;
+                return false;
+            }
+
+            // Find baby and food
+            Thing food;
+            Pawn baby = ChildcareUtility.FindAutofeedBaby(pawn, AutofeedMode.Urgent, out food);
+
+            if (baby == null || !baby.Spawned)
+            {
+                __result = null;
+                return false;
+            }
+
+            // Prioritize checking for breastfeeders
+            if (food != pawn && ChildcareUtility.ImmobileBreastfeederAvailable(pawn, baby, forced: false, out var feeder, out var _))
+            {
+                food = feeder;
+            }
+
+            // If the food source is a MealPrinter, search for alternative edible sources
+            if (food is Building_MealPrinter)
+            {
+                food = FindAlternativeBabyFood(pawn, baby);
+                if (food == null)
+                {
+                    __result = null;
+                    return false;
+                }
+            }
+
+            // Proceed with job if valid food is found
+            if (food != null)
+            {
+                __result = ChildcareUtility.MakeAutofeedBabyJob(pawn, baby, food);
+                return false;
+            }
+
+            __result = null;
+            return false;
+        }
+
+        // Searches for any edible baby food, insect jelly, or milk in the map
+        private static Thing FindAlternativeBabyFood(Pawn pawn, Pawn baby)
+        {
+            List<Thing> potentialFoods = new List<Thing>();
+            if (baby.foodRestriction.BabyFoodAllowed(ThingDefOf.BabyFood))
+            {
+                potentialFoods.AddRange(pawn.Map.listerThings.ThingsOfDef(ThingDefOf.BabyFood));
+            }
+            if (baby.foodRestriction.BabyFoodAllowed(ThingDef.Named("InsectJelly")))
+            {
+                potentialFoods.AddRange(pawn.Map.listerThings.ThingsOfDef(ThingDef.Named("InsectJelly")));
+            }
+            if (baby.foodRestriction.BabyFoodAllowed(ThingDef.Named("Milk")))
+            {
+                potentialFoods.AddRange(pawn.Map.listerThings.ThingsOfDef(ThingDef.Named("Milk")));
+            }
+
+            foreach (Thing food in potentialFoods)
+            {
+                if (pawn.CanReserve(food) && food.stackCount > 0)
+                {
+                    // Ensure the food is edible by the baby
+                    if (FoodUtility.WillIngestFromInventoryNow(baby, food))
+                    {
+                        return food;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/MealPrinter/Harmony_WorkGiver_BottleFeedBaby.cs
+++ b/Source/MealPrinter/Harmony_WorkGiver_BottleFeedBaby.cs
@@ -1,0 +1,90 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+using Verse.AI;
+
+namespace MealPrinter
+{
+
+    [HarmonyPatch(typeof(WorkGiver_BottleFeedBaby), "JobOnThing")]
+    public static class Harmony_WorkGiver_BottleFeedBaby_JobOnThing
+    {
+        public static bool Prefix(WorkGiver_BottleFeedBaby __instance, ref Job __result, Pawn pawn, Thing t, bool forced)
+        {
+            // Run original checks
+            if (!__instance.CanCreateManualFeedingJob(pawn, t, forced))
+            {
+                __result = null;
+                return false;  // Skip the original method
+            }
+
+            Pawn baby = (Pawn)t;
+
+            // Look for food, prioritizing multiple sources
+            Thing foodSource = FindAlternativeBabyFood(pawn, baby);
+
+            // **Block Meal Printer**
+            if (foodSource is Building_MealPrinter)
+            {
+                JobFailReason.Is("NoBabyFood".Translate());
+                __result = null;
+                return false;
+            }
+
+            // Fail if no valid food is found
+            if (foodSource == null)
+            {
+                JobFailReason.Is("NoBabyFood".Translate());
+                __result = null;
+                return false;
+            }
+
+            // Create the bottle-feeding job with the found food source
+            __result = ChildcareUtility.MakeBottlefeedJob(baby, foodSource);
+            return false;  // Skip the original method since we've handled the result
+        }
+
+        // Searches for Baby Food, Insect Jelly, or Milk on the map
+        private static Thing FindAlternativeBabyFood(Pawn pawn, Pawn baby)
+        {
+            List<Thing> potentialFoods = new List<Thing>();
+            if (baby.foodRestriction.BabyFoodAllowed(ThingDefOf.BabyFood))
+            {
+                potentialFoods.AddRange(pawn.Map.listerThings.ThingsOfDef(ThingDefOf.BabyFood));
+            }
+            if (baby.foodRestriction.BabyFoodAllowed(ThingDef.Named("InsectJelly")))
+            {
+                potentialFoods.AddRange(pawn.Map.listerThings.ThingsOfDef(ThingDef.Named("InsectJelly")));
+            }
+            if (baby.foodRestriction.BabyFoodAllowed(ThingDef.Named("Milk")))
+            {
+                potentialFoods.AddRange(pawn.Map.listerThings.ThingsOfDef(ThingDef.Named("Milk")));
+            }
+
+            foreach (Thing food in potentialFoods)
+            {
+                // **Skip Meal Printer Directly**
+                if (food is Building_MealPrinter)
+                {
+                    continue;  // Ignore the meal printer entirely
+                }
+
+                if (pawn.CanReserve(food) && food.stackCount > 0)
+                {
+                    // Ensure the food is edible by the baby
+                    if (FoodUtility.WillIngestFromInventoryNow(baby, food))
+                    {
+                        return food;
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
I initially wanted to allow babies to be fed from the printer, but the toils weren't behaving and I got tired of it. Instead, these two patches prevent any attempts at using the printer to feed babies. Breastfeeding and vanilla baby-edible foods (and their restrictions) are respected. Could probably use some expansion (detect any and all baby-edible foods to catch anything modded, etc.) but this clears the errors and provides basic Biotech compatibility.